### PR TITLE
fix: captalize all words after exclamation marks

### DIFF
--- a/src/epub/text/act-1.xhtml
+++ b/src/epub/text/act-1.xhtml
@@ -160,7 +160,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Algernon</td>
-						<td>Oh! merely Aunt Augusta and Gwendolen.</td>
+						<td>Oh! Merely Aunt Augusta and Gwendolen.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>
@@ -200,7 +200,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Algernon</td>
-						<td>Oh! there is no use speculating on that subject. Divorces are made in Heaven⁠—<i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Jack</b> puts out his hand to take a sandwich. <b epub:type="z3998:persona">Algernon</b> at once interferes.</i> Please don’t touch the cucumber sandwiches. They are ordered specially for Aunt Augusta. <i epub:type="z3998:stage-direction">Takes one and eats it.</i></td>
+						<td>Oh! There is no use speculating on that subject. Divorces are made in Heaven⁠—<i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Jack</b> puts out his hand to take a sandwich. <b epub:type="z3998:persona">Algernon</b> at once interferes.</i> Please don’t touch the cucumber sandwiches. They are ordered specially for Aunt Augusta. <i epub:type="z3998:stage-direction">Takes one and eats it.</i></td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>
@@ -288,7 +288,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Algernon</td>
-						<td>Oh! it is absurd to have a hard and fast rule about what one should read and what one shouldn’t. More than half of modern culture depends on what one shouldn’t read.</td>
+						<td>Oh! It is absurd to have a hard and fast rule about what one should read and what one shouldn’t. More than half of modern culture depends on what one shouldn’t read.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>
@@ -448,7 +448,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Algernon</td>
-						<td>My dear fellow, it isn’t easy to be anything nowadays. There’s such a lot of beastly competition about. <i epub:type="z3998:stage-direction">The sound of an electric bell is heard.</i> Ah! that must be Aunt Augusta. Only relatives, or creditors, ever ring in that Wagnerian manner. Now, if I get her out of the way for ten minutes, so that you can have an opportunity for proposing to Gwendolen, may I dine with you tonight at Willis’s?</td>
+						<td>My dear fellow, it isn’t easy to be anything nowadays. There’s such a lot of beastly competition about. <i epub:type="z3998:stage-direction">The sound of an electric bell is heard.</i> Ah! That must be Aunt Augusta. Only relatives, or creditors, ever ring in that Wagnerian manner. Now, if I get her out of the way for ten minutes, so that you can have an opportunity for proposing to Gwendolen, may I dine with you tonight at Willis’s?</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>
@@ -662,7 +662,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Gwendolen</td>
-						<td><i epub:type="z3998:stage-direction">Glibly.</i> Ah! that is clearly a metaphysical speculation, and like most metaphysical speculations has very little reference at all to the actual facts of real life, as we know them.</td>
+						<td><i epub:type="z3998:stage-direction">Glibly.</i> Ah! That is clearly a metaphysical speculation, and like most metaphysical speculations has very little reference at all to the actual facts of real life, as we know them.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>
@@ -1004,7 +1004,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Algernon</td>
-						<td>It is perfectly phrased! and quite as true as any observation in civilised life should be.</td>
+						<td>It is perfectly phrased! And quite as true as any observation in civilised life should be.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>
@@ -1020,7 +1020,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Algernon</td>
-						<td>The fools? Oh! about the clever people, of course.</td>
+						<td>The fools? Oh! About the clever people, of course.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>
@@ -1088,7 +1088,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>
-						<td>Oh! one doesn’t blurt these things out to people. Cecily and Gwendolen are perfectly certain to be extremely great friends. I’ll bet you anything you like that half an hour after they have met, they will be calling each other sister.</td>
+						<td>Oh! One doesn’t blurt these things out to people. Cecily and Gwendolen are perfectly certain to be extremely great friends. I’ll bet you anything you like that half an hour after they have met, they will be calling each other sister.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Algernon</td>
@@ -1298,7 +1298,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>
-						<td>There’s a sensible, intellectual girl! the only girl I ever cared for in my life. <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Algernon</b> is laughing immoderately.</i> What on earth are you so amused at?</td>
+						<td>There’s a sensible, intellectual girl! The only girl I ever cared for in my life. <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Algernon</b> is laughing immoderately.</i> What on earth are you so amused at?</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Algernon</td>

--- a/src/epub/text/act-2.xhtml
+++ b/src/epub/text/act-2.xhtml
@@ -86,7 +86,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Miss Prism</td>
-						<td>Alas! no. The manuscript unfortunately was abandoned. <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Cecily</b> starts.</i> I use the word in the sense of lost or mislaid. To your work, child, these speculations are profitless.</td>
+						<td>Alas! No. The manuscript unfortunately was abandoned. <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Cecily</b> starts.</i> I use the word in the sense of lost or mislaid. To your work, child, these speculations are profitless.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Cecily</td>
@@ -502,7 +502,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>
-						<td>Ah! that reminds me, you mentioned christenings I think, <abbr>Dr.</abbr> Chasuble? I suppose you know how to christen all right? <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona"><abbr>Dr.</abbr> Chasuble</b> looks astounded.</i> I mean, of course, you are continually christening, aren’t you?</td>
+						<td>Ah! That reminds me, you mentioned christenings I think, <abbr>Dr.</abbr> Chasuble? I suppose you know how to christen all right? <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona"><abbr>Dr.</abbr> Chasuble</b> looks astounded.</i> I mean, of course, you are continually christening, aren’t you?</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Miss Prism</td>
@@ -522,7 +522,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>
-						<td>But it is not for any child, dear Doctor. I am very fond of children. No! the fact is, I would like to be christened myself, this afternoon, if you have nothing better to do.</td>
+						<td>But it is not for any child, dear Doctor. I am very fond of children. No! The fact is, I would like to be christened myself, this afternoon, if you have nothing better to do.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Chasuble</td>
@@ -588,7 +588,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Chasuble</td>
-						<td>My child! my child! <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Cecily</b> goes towards <b epub:type="z3998:persona">Jack</b>; he kisses her brow in a melancholy manner.</i></td>
+						<td>My child! My child! <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Cecily</b> goes towards <b epub:type="z3998:persona">Jack</b>; he kisses her brow in a melancholy manner.</i></td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Cecily</td>
@@ -650,7 +650,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>
-						<td>Oh! he has been talking about Bunbury, has he?</td>
+						<td>Oh! He has been talking about Bunbury, has he?</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Cecily</td>
@@ -1212,7 +1212,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Cecily</td>
-						<td>Oh! not at all, Gwendolen. I am very fond of being looked at.</td>
+						<td>Oh! Not at all, Gwendolen. I am very fond of being looked at.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Gwendolen</td>
@@ -1280,7 +1280,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Gwendolen</td>
-						<td>Ah! that accounts for it. And now that I think of it I have never heard any man mention his brother. The subject seems distasteful to most men. Cecily, you have lifted a load from my mind. I was growing almost anxious. It would have been terrible if any cloud had come across a friendship like ours, would it not? Of course you are quite, quite sure that it is not <abbr>Mr.</abbr> Ernest Worthing who is your guardian?</td>
+						<td>Ah! That accounts for it. And now that I think of it I have never heard any man mention his brother. The subject seems distasteful to most men. Cecily, you have lifted a load from my mind. I was growing almost anxious. It would have been terrible if any cloud had come across a friendship like ours, would it not? Of course you are quite, quite sure that it is not <abbr>Mr.</abbr> Ernest Worthing who is your guardian?</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Cecily</td>
@@ -1350,7 +1350,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Cecily</td>
-						<td>Oh! yes! a great many. From the top of one of the hills quite close one can see five counties.</td>
+						<td>Oh! Yes! A great many. From the top of one of the hills quite close one can see five counties.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Gwendolen</td>
@@ -1496,7 +1496,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Cecily</td>
-						<td>Yes! to good heavens, Gwendolen, I mean to Gwendolen.</td>
+						<td>Yes! To good heavens, Gwendolen, I mean to Gwendolen.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Algernon</td>
@@ -1758,7 +1758,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Algernon</td>
-						<td>I haven’t quite finished my tea yet! and there is still one muffin left. <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Jack</b> groans, and sinks into a chair. <b epub:type="z3998:persona">Algernon</b> still continues eating.</i></td>
+						<td>I haven’t quite finished my tea yet! And there is still one muffin left. <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Jack</b> groans, and sinks into a chair. <b epub:type="z3998:persona">Algernon</b> still continues eating.</i></td>
 					</tr>
 				</tbody>
 			</table>

--- a/src/epub/text/act-3.xhtml
+++ b/src/epub/text/act-3.xhtml
@@ -306,15 +306,15 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Lady Bracknell</td>
-						<td>Ah! A life crowded with incident, I see; though perhaps somewhat too exciting for a young girl. I am not myself in favour of premature experiences. <i epub:type="z3998:stage-direction">Rises, looks at her watch.</i> Gwendolen! the time approaches for our departure. We have not a moment to lose. As a matter of form, <abbr>Mr.</abbr> Worthing, I had better ask you if Miss Cardew has any little fortune?</td>
+						<td>Ah! A life crowded with incident, I see; though perhaps somewhat too exciting for a young girl. I am not myself in favour of premature experiences. <i epub:type="z3998:stage-direction">Rises, looks at her watch.</i> Gwendolen! The time approaches for our departure. We have not a moment to lose. As a matter of form, <abbr>Mr.</abbr> Worthing, I had better ask you if Miss Cardew has any little fortune?</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>
-						<td>Oh! about a hundred and thirty thousand pounds in the Funds. That is all. Goodbye, Lady Bracknell. So pleased to have seen you.</td>
+						<td>Oh! About a hundred and thirty thousand pounds in the Funds. That is all. Goodbye, Lady Bracknell. So pleased to have seen you.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Lady Bracknell</td>
-						<td><i epub:type="z3998:stage-direction">Sitting down again.</i> A moment, <abbr>Mr.</abbr> Worthing. A hundred and thirty thousand pounds! And in the Funds! Miss Cardew seems to me a most attractive young lady, now that I look at her. Few girls of the present day have any really solid qualities, any of the qualities that last, and improve with time. We live, I regret to say, in an age of surfaces. <i epub:type="z3998:stage-direction">To <b epub:type="z3998:persona">Cecily</b>.</i> Come over here, dear. <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Cecily</b> goes across.</i> Pretty child! your dress is sadly simple, and your hair seems almost as Nature might have left it. But we can soon alter all that. A thoroughly experienced French maid produces a really marvellous result in a very brief space of time. I remember recommending one to young Lady Lancing, and after three months her own husband did not know her.</td>
+						<td><i epub:type="z3998:stage-direction">Sitting down again.</i> A moment, <abbr>Mr.</abbr> Worthing. A hundred and thirty thousand pounds! And in the Funds! Miss Cardew seems to me a most attractive young lady, now that I look at her. Few girls of the present day have any really solid qualities, any of the qualities that last, and improve with time. We live, I regret to say, in an age of surfaces. <i epub:type="z3998:stage-direction">To <b epub:type="z3998:persona">Cecily</b>.</i> Come over here, dear. <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Cecily</b> goes across.</i> Pretty child! Your dress is sadly simple, and your hair seems almost as Nature might have left it. But we can soon alter all that. A thoroughly experienced French maid produces a really marvellous result in a very brief space of time. I remember recommending one to young Lady Lancing, and after three months her own husband did not know her.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Jack</td>


### PR DESCRIPTION
Given [this specification](https://standardebooks.org/manual/1.0.0/8-typography#8.3.1) that states "In general, capitalization follows modern English style" I believe that this pull request is warranted.

The current text has a mixture of capatalized and non-capatalized words after exclamation marks (so does the [Gutenberg version](https://www.gutenberg.org/files/844/844-h/844-h.htm)).

[This stack exchange post](https://english.stackexchange.com/questions/353214/should-i-capitalize-after-an-exclamation-in-dialogue) also covers this topic.